### PR TITLE
add code to remove percent signs before trying to parse them as ints

### DIFF
--- a/crates/ooxmlsdk-build/src/generator/deserializer.rs
+++ b/crates/ooxmlsdk-build/src/generator/deserializer.rs
@@ -901,6 +901,7 @@ fn gen_field_match_arm(attr: &OpenXmlSchemaTypeAttribute, gen_context: &GenConte
             #attr_name_ident = Some(
               attr
                 .decode_and_unescape_value(xml_reader.decoder())?
+                .replace("%", "000")
                 .parse::<#e_type>()?,
             );
           }

--- a/crates/ooxmlsdk-build/src/generator/deserializer.rs
+++ b/crates/ooxmlsdk-build/src/generator/deserializer.rs
@@ -898,12 +898,14 @@ fn gen_field_match_arm(attr: &OpenXmlSchemaTypeAttribute, gen_context: &GenConte
 
         quote! {
           #attr_name_literal => {
-            #attr_name_ident = Some(
-              attr
-                .decode_and_unescape_value(xml_reader.decoder())?
-                .replace("%", "000")
-                .parse::<#e_type>()?,
-            );
+            let e_value = attr.decode_and_unescape_value(xml_reader.decoder())?;
+            if e_value.ends_with("%") {
+              let e_float: f64 = e_value[..e_value.len() - 1].parse()?;
+              // Scale the 0..100 to 0..100000
+              #attr_name_ident = Some((e_float * 1000.0) as #e_type)
+            } else {
+              #attr_name_ident = Some(e_value.parse::<#e_type>()?);
+            }
           }
         }
       }


### PR DESCRIPTION
This should fix some or all of the ParseIntError issues listed [here](https://renewedvision.slack.com/archives/C08PAN4EMA7/p1758636236911729)

These are due to attributes like  `b="100%"` in some files. This changes the % to a 000, which works as long as the part before the % is an int, but in this case it should be.