### PR TITLE
Relax formula requirements

### DIFF
--- a/crates/ooxmlsdk/data/schemas/schemas_openxmlformats_org_drawingml_2006_chart.json
+++ b/crates/ooxmlsdk/data/schemas/schemas_openxmlformats_org_drawingml_2006_chart.json
@@ -2975,7 +2975,12 @@
         "Kind": "Sequence",
         "Items": [
           {
-            "Name": "xsd:string/c:f"
+            "Name": "xsd:string/c:f",
+            "Occurs": [
+              {
+                "Max": 1
+              }
+            ]
           },
           {
             "Name": "c:CT_NumData/c:numCache",
@@ -3196,7 +3201,12 @@
         "Kind": "Sequence",
         "Items": [
           {
-            "Name": "xsd:string/c:f"
+            "Name": "xsd:string/c:f",
+            "Occurs": [
+              {
+                "Max": 1
+              }
+            ]
           },
           {
             "Name": "c:CT_MultiLvlStrData/c:multiLvlStrCache",

--- a/crates/ooxmlsdk/data/schemas/schemas_openxmlformats_org_drawingml_2006_chart.json
+++ b/crates/ooxmlsdk/data/schemas/schemas_openxmlformats_org_drawingml_2006_chart.json
@@ -3241,7 +3241,12 @@
         "Kind": "Sequence",
         "Items": [
           {
-            "Name": "xsd:string/c:f"
+            "Name": "xsd:string/c:f",
+            "Occurs": [
+              {
+                "Max": 1
+              }
+            ]
           },
           {
             "Name": "c:CT_StrData/c:strCache",


### PR DESCRIPTION
This fixes an issue with the "Complex Presentation - Jon Bridges.pptx" presentation from our sample data. 

According to the OOXML schema, a formula (c:f) element is required in a strRef in a drawing/chart. In 2012, MS added an extension called formulaRef (c15:formulaRef). While the original schema can't be modified, it appears that PowerPoint for Mac v16 doesn't care that formula is still required, and only outputs the extension. 

This PR relaxes the requirements on strRef and two related types, allowing formula to be optional. That does change the type of formula in the generated Rust code to also be optional, so this is a breaking change for anyone who was using formula (not us.) 