### PR TITLE
Add support for external relationship targets

### DIFF
--- a/crates/ooxmlsdk-build/src/generator/deserializer.rs
+++ b/crates/ooxmlsdk-build/src/generator/deserializer.rs
@@ -842,7 +842,7 @@ fn gen_simple_child_match_arm(first_name: &str, gen_context: &GenContext) -> Arm
 }
 
 fn gen_simple_child_entity_arm(first_name: &str, gen_context: &GenContext, arms: &mut Vec<Arm>) {
-  if gen_context.enum_type_enum_map.get(first_name).is_none() {
+  if !gen_context.enum_type_enum_map.contains_key(first_name) {
     let simple_type_str = simple_type_mapping(first_name);
 
     if simple_type_str == "StringValue" {
@@ -941,8 +941,8 @@ fn gen_field_match_arm(attr: &OpenXmlSchemaTypeAttribute, gen_context: &GenConte
         quote! {
           #attr_name_literal => {
             let e_value = attr.decode_and_unescape_value(xml_reader.decoder())?;
-            if e_value.ends_with("%") {
-              let e_float: f64 = e_value[..e_value.len() - 1].parse()?;
+            if let Some(stripped) = e_value.strip_suffix("%") {
+              let e_float: f64 = stripped.parse()?;
               // Scale the 0..100 to 0..100000
               #attr_name_ident = Some((e_float * 1000.0) as #e_type)
             } else {

--- a/crates/ooxmlsdk-build/src/generator/open_xml_part.rs
+++ b/crates/ooxmlsdk-build/src/generator/open_xml_part.rs
@@ -280,13 +280,18 @@ pub fn gen_open_xml_parts(part: &OpenXmlPart, gen_context: &GenContext) -> Token
 
     field_declaration_list.push(
       parse2(quote! {
-        {
-          let mut zip_entry = archive.by_name(path)?;
+        match r_mode {
+          Some(crate::schemas::opc_relationships::TargetMode::External) => {
+            part_content = std::fs::read(path).unwrap_or_default();
+          }
+          _ => {
+            let mut zip_entry = archive.by_name(path)?;
 
-          part_content = Vec::with_capacity(zip_entry.size() as usize);
+            part_content = Vec::with_capacity(zip_entry.size() as usize);
 
-          zip_entry.read_to_end(&mut part_content)?;
-        }
+            zip_entry.read_to_end(&mut part_content)?;
+          },
+        };
       })
       .unwrap(),
     );
@@ -387,14 +392,18 @@ pub fn gen_open_xml_parts(part: &OpenXmlPart, gen_context: &GenContext) -> Token
       children_arm_list.push(
         parse2(quote! {
           #relationship_type_ty => {
-            let target_path = crate::common::resolve_zip_file_path(
-              &format!("{}{}", child_parent_path, relationship.target),
-            );
+            let target_path = match relationship.target_mode.as_ref() {
+              Some(crate::schemas::opc_relationships::TargetMode::External) => relationship.target.clone(),
+              _ => crate::common::resolve_zip_file_path(
+                  &format!("{}{}", child_parent_path, relationship.target),
+              ),
+            };
 
             let #child_name_ident = #child_type::new_from_archive(
               &child_parent_path,
               &target_path,
               &relationship.id,
+              relationship.target_mode.as_ref(),
               file_path_set,
               archive,
             )?;
@@ -415,14 +424,18 @@ pub fn gen_open_xml_parts(part: &OpenXmlPart, gen_context: &GenContext) -> Token
       children_arm_list.push(
         parse2(quote! {
           #relationship_type_ty => {
-            let target_path = crate::common::resolve_zip_file_path(
-              &format!("{}{}", child_parent_path, relationship.target),
-            );
+            let target_path = match relationship.target_mode.as_ref() {
+              Some(crate::schemas::opc_relationships::TargetMode::External) => relationship.target.clone(),
+              _ => crate::common::resolve_zip_file_path(
+                  &format!("{}{}", child_parent_path, relationship.target),
+              ),
+            };
 
             #child_api_name_ident = Some(std::boxed::Box::new(#child_type::new_from_archive(
               &child_parent_path,
               &target_path,
               &relationship.id,
+              relationship.target_mode.as_ref(),
               file_path_set,
               archive,
             )?));
@@ -479,6 +492,7 @@ pub fn gen_open_xml_parts(part: &OpenXmlPart, gen_context: &GenContext) -> Token
       parent_path: &str,
       path: &str,
       r_id: &str,
+      r_mode: Option<&crate::schemas::opc_relationships::TargetMode>,
       file_path_set: &std::collections::HashSet<String>,
       archive: &mut zip::ZipArchive<R>,
     ) -> Result<Self, crate::common::SdkError> {
@@ -736,7 +750,7 @@ pub fn gen_open_xml_parts(part: &OpenXmlPart, gen_context: &GenContext) -> Token
           file_path_set.insert(file_path);
         }
 
-        Self::new_from_archive("", "", "", &file_path_set, &mut archive)
+        Self::new_from_archive("", "", "", None, &file_path_set, &mut archive)
       }
     })
     .unwrap();

--- a/crates/ooxmlsdk-build/src/includes/packages/opc_relationships.rs
+++ b/crates/ooxmlsdk-build/src/includes/packages/opc_relationships.rs
@@ -335,7 +335,7 @@ impl Relationship {
   }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub enum TargetMode {
   #[default]
   External,


### PR DESCRIPTION
Previously, the code was completely ignoring the `TargetMode` field on the `Relationship` element, and tried to read everything from inside the zip archive. If `TargetMode` is `External`, then the target is _not_ in the zip file, but is a reference to a file existing elsewhere on the filesystem or on the internet.

This causes an issue with the `video` relationships, because PowerPoint seems to insert an external relationship with a target path of `NULL` (i.e. a string containing the word `NULL`) if you edit the attributes of the file to the point where it can't emit legacy XML to support it (such as the begin/end trim). In this case, however, the `video` reference is overridden with a later `media` reference, which resolves to a correct path.

I have changed it to support files elsewhere on the filesystem (and simply store zero-length content if the file does not exist), but there is still not support for internet URLs. I don't foresee this to be a major issue.

The changes to `deserializer.rs` are just to fix clippy warnings.