### PR TITLE
Implement proper namespace handling

### DIFF
--- a/crates/ooxmlsdk-build/src/generator/deserializer.rs
+++ b/crates/ooxmlsdk-build/src/generator/deserializer.rs
@@ -115,8 +115,6 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
     let type_name_str = &prefix_type_name_str
       [prefix_type_name_str.find(':').unwrap() + 1..prefix_type_name_str.len()];
 
-    let prefix_type_name_literal: LitByteStr =
-      parse_str(&format!("b\"{prefix_type_name_str}\"")).unwrap();
     let type_name_literal: LitByteStr = parse_str(&format!("b\"{type_name_str}\"")).unwrap();
 
     let mut field_declaration_list: Vec<Stmt> = vec![];
@@ -176,13 +174,6 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
         field_declaration_list.push(
           parse2(quote! {
             let mut xmlns = None;
-          })
-          .unwrap(),
-        );
-
-        field_declaration_list.push(
-          parse2(quote! {
-            let mut xmlns_map = std::collections::HashMap::<String, String>::new();
           })
           .unwrap(),
         );
@@ -459,8 +450,9 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
 
     let mut expect_event_start_stmt: Stmt = parse2(quote! {
       let (e, empty_tag) =
-        crate::common::expect_event_start!(xml_reader, xml_event, #prefix_type_name_literal, #type_name_literal);
-    }).unwrap();
+        crate::common::expect_event_start!(xml_reader, xml_event, #type_name_literal, xmlns_map);
+    })
+    .unwrap();
 
     let attr_match_stmt_opt: Option<Stmt> = if (t.base_class == "OpenXmlCompositeElement"
       || t.base_class == "CustomXmlElement"
@@ -484,14 +476,7 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
               b"mc:Ignorable" => {
                 mc_ignorable = Some(attr.decode_and_unescape_value(xml_reader.decoder())?.into_owned());
               }
-              key => {
-                if key.starts_with(b"xmlns:") {
-                  xmlns_map.insert(
-                    String::from_utf8_lossy(&key[6..]).to_string(),
-                    attr.decode_and_unescape_value(xml_reader.decoder())?.into_owned(),
-                  );
-                }
-              }
+              _ => (),
             }
           }
         })
@@ -515,8 +500,9 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
     } else {
       expect_event_start_stmt = parse2(quote! {
         let (_, empty_tag) =
-          crate::common::expect_event_start!(xml_reader, xml_event, #prefix_type_name_literal, #type_name_literal);
-      }).unwrap();
+          crate::common::expect_event_start!(xml_reader, xml_event, #type_name_literal, xmlns_map);
+      })
+      .unwrap();
 
       None
     };
@@ -539,7 +525,7 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
       loop_match_arm_list.push(
         parse2(quote! {
           quick_xml::events::Event::Start(e) => {
-            e_opt = alternate_content_stack.on_start(e, xml_reader)?;
+            e_opt = alternate_content_stack.on_start(e, xml_reader, &mut xmlns_map)?;
           }
         })
         .unwrap(),
@@ -575,7 +561,8 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
       loop_children_stmt_opt = Some(
         parse2(quote! {
           if let Some(e) = e_opt {
-            match e.name().as_ref() {
+            crate::common::update_namespace_map(xml_reader, &e, &mut xmlns_map)?;
+            match (e.local_name().as_ref(), crate::common::get_element_namespace(&e, &xmlns_map)?) {
               #( #loop_children_match_list )*
             }
           }
@@ -588,6 +575,7 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
       pub(crate) fn deserialize_inner<'de, R: crate::common::XmlReader<'de>>(
         xml_reader: &mut R,
         xml_event: Option<(quick_xml::events::BytesStart<'de>, bool)>,
+        mut xmlns_map: std::collections::HashMap<String, String>,
       ) -> Result<Self, crate::common::SdkError> {
         #expect_event_start_stmt
 
@@ -603,13 +591,13 @@ pub fn gen_deserializers(schema: &OpenXmlSchema, gen_context: &GenContext) -> To
 
             match xml_reader.next()? {
               #( #loop_match_arm_list )*
-              quick_xml::events::Event::End(e) => match e.name().as_ref() {
-                #prefix_type_name_literal | #type_name_literal => {
+              quick_xml::events::Event::End(e) => match e.local_name().as_ref() {
+                #type_name_literal => {
                   break;
                 }
                 _ => alternate_content_stack.on_end(e)?,
               },
-              quick_xml::events::Event::Eof => Err(crate::common::SdkError::UnknownError)?,
+              quick_xml::events::Event::Eof => Err(crate::common::SdkError::CommonError("Unexpected end of file".into()))?,
               _ => (),
             }
 
@@ -651,7 +639,7 @@ fn gen_from_str_impl(struct_type: &Type) -> ItemImpl {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut xml_reader = crate::common::from_str_inner(s)?;
 
-        Self::deserialize_inner(&mut xml_reader, None)
+        Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
       }
     }
   };
@@ -666,7 +654,7 @@ fn gen_from_reader_fn() -> ItemFn {
     ) -> Result<Self, crate::common::SdkError> {
       let mut xml_reader = crate::common::from_reader_inner(reader)?;
 
-      Self::deserialize_inner(&mut xml_reader, None)
+      Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
     }
   };
 
@@ -691,8 +679,6 @@ fn gen_one_sequence_match_arm(
     parse_str(&escape_snake_case(child.property_name.to_snake_case())).unwrap()
   };
 
-  let child_last_name_literal: LitByteStr = parse_str(&format!("b\"{child_last_name}\"")).unwrap();
-
   let child_suffix_last_name_literal: LitByteStr =
     parse_str(&format!("b\"{child_suffix_last_name}\"")).unwrap();
 
@@ -703,21 +689,25 @@ fn gen_one_sequence_match_arm(
   ))
   .unwrap();
 
+  let prefix = &child_last_name[0..child_last_name.find(':').unwrap()];
+  let namespace = &gen_context.prefix_namespace_map.get(prefix).unwrap().uri;
+  let namespace_literal: syn::LitStr = parse_str(&format!("\"{namespace}\"")).unwrap();
+
   if loop_children_suffix_match_set.insert(child_suffix_last_name.to_string()) {
     if p.occurs.is_empty() || (p.occurs[0].min == 0 && p.occurs[0].max == 1) {
       parse2(quote! {
-        #child_last_name_literal | #child_suffix_last_name_literal => {
+        (#child_suffix_last_name_literal, #namespace_literal) => {
           #child_name_ident = Some(std::boxed::Box::new(
-            #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)))?,
+            #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)), xmlns_map.clone())?,
           ));
         }
       })
       .unwrap()
     } else {
       parse2(quote! {
-        #child_last_name_literal | #child_suffix_last_name_literal => {
+        (#child_suffix_last_name_literal, #namespace_literal) => {
           #child_name_ident.push(
-            #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)))?,
+            #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)), xmlns_map.clone())?,
           );
         }
       })
@@ -725,18 +715,18 @@ fn gen_one_sequence_match_arm(
     }
   } else if p.occurs.is_empty() || (p.occurs[0].min == 0 && p.occurs[0].max == 1) {
     parse2(quote! {
-      #child_last_name_literal => {
+      (#child_suffix_last_name_literal, #namespace_literal) => {
         #child_name_ident = Some(std::boxed::Box::new(
-          #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)))?,
+          #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)), xmlns_map.clone())?,
         ));
       }
     })
     .unwrap()
   } else {
     parse2(quote! {
-      #child_last_name_literal => {
+      (#child_suffix_last_name_literal, #namespace_literal) => {
         #child_name_ident.push(
-          #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)))?,
+          #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)), xmlns_map.clone())?,
         );
       }
     })
@@ -756,8 +746,6 @@ fn gen_child_match_arm(
   let child_suffix_last_name =
     &child_last_name[child_last_name.find(':').unwrap() + 1..child_last_name.len()];
 
-  let child_last_name_literal: LitByteStr = parse_str(&format!("b\"{child_last_name}\"")).unwrap();
-
   let child_suffix_last_name_literal: LitByteStr =
     parse_str(&format!("b\"{child_suffix_last_name}\"")).unwrap();
 
@@ -770,25 +758,19 @@ fn gen_child_match_arm(
   ))
   .unwrap();
 
-  if loop_children_suffix_match_set.insert(child_suffix_last_name.to_string()) {
-    parse2(quote! {
-      #child_last_name_literal | #child_suffix_last_name_literal => {
-        children.push(#child_choice_enum_ident::#child_variant_name_ident(std::boxed::Box::new(
-          #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)))?,
-        )));
-      }
-    })
-    .unwrap()
-  } else {
-    parse2(quote! {
-      #child_last_name_literal => {
-        children.push(#child_choice_enum_ident::#child_variant_name_ident(std::boxed::Box::new(
-          #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)))?,
-        )));
-      }
-    })
-    .unwrap()
-  }
+  let prefix = &child_last_name[0..child_last_name.find(':').unwrap()];
+  let namespace = &gen_context.prefix_namespace_map.get(prefix).unwrap().uri;
+  let namespace_literal: syn::LitStr = parse_str(&format!("\"{namespace}\"")).unwrap();
+
+  loop_children_suffix_match_set.insert(child_suffix_last_name.to_string());
+  parse2(quote! {
+    (#child_suffix_last_name_literal, #namespace_literal) => {
+      children.push(#child_choice_enum_ident::#child_variant_name_ident(std::boxed::Box::new(
+        #child_variant_type::deserialize_inner(xml_reader, Some((e, e_empty)), xmlns_map.clone())?,
+      )));
+    }
+  })
+  .unwrap()
 }
 
 fn gen_simple_child_match_arm(first_name: &str, gen_context: &GenContext) -> Arm {

--- a/crates/ooxmlsdk-build/src/generator/open_xml_schema.rs
+++ b/crates/ooxmlsdk-build/src/generator/open_xml_schema.rs
@@ -51,7 +51,7 @@ pub fn gen_open_xml_schemas(schema: &OpenXmlSchema, gen_context: &GenContext) ->
     }
 
     token_stream_list.push(quote! {
-      #[derive(Clone, Debug, Default)]
+      #[derive(Clone, Debug, Default, PartialEq)]
       pub enum #e_enum_name_ident {
         #( #variants, )*
       }

--- a/crates/ooxmlsdk-build/src/includes/common.rs
+++ b/crates/ooxmlsdk-build/src/includes/common.rs
@@ -1,9 +1,11 @@
 use quick_xml::{
   encoding::EncodingError,
   events::{attributes::AttrError, Event},
+  name::PrefixDeclaration,
   Decoder, Reader,
 };
 use std::{
+  collections::HashMap,
   io::BufRead,
   num::{ParseFloatError, ParseIntError},
 };
@@ -16,29 +18,27 @@ pub use alternate_content::AlternateContentStack;
 
 #[derive(Error, Debug)]
 pub enum SdkError {
-  #[error("quick_xml error")]
+  #[error("quick_xml error: {0:?}")]
   QuickXmlError(#[from] quick_xml::Error),
-  #[error("quick_xml encoding error")]
+  #[error("quick_xml encoding error: {0:?}")]
   QuickEncodingError(#[from] EncodingError),
-  #[error("quick_xml attr error")]
+  #[error("quick_xml attr error: {0:?}")]
   AttrError(#[from] AttrError),
-  #[error("ParseIntError")]
+  #[error("ParseIntError: {0:?}")]
   ParseIntError(#[from] ParseIntError),
-  #[error("ParseFloatError")]
+  #[error("ParseFloatError: {0:?}")]
   ParseFloatError(#[from] ParseFloatError),
-  #[error("StdFmtError")]
+  #[error("StdFmtError: {0:?}")]
   StdFmtError(#[from] std::fmt::Error),
-  #[error("StdIoError")]
+  #[error("StdIoError: {0:?}")]
   StdIoError(#[from] std::io::Error),
   #[cfg(feature = "parts")]
-  #[error("ZipError")]
+  #[error("ZipError: {0:?}")]
   ZipError(#[from] zip::result::ZipError),
   #[error("mismatch error (expected {expected:?}, found {found:?})")]
   MismatchError { expected: String, found: String },
   #[error("`{0}` common error")]
   CommonError(String),
-  #[error("unknown error")]
-  UnknownError,
 }
 
 pub trait XmlReader<'de> {
@@ -147,7 +147,7 @@ pub fn parse_bool_bytes(b: &[u8]) -> Result<bool, SdkError> {
 }
 
 macro_rules! expect_event_start {
-  ($xml_reader:expr, $xml_event:expr, $tag_prefix:expr, $tag:expr) => {{
+  ($xml_reader:expr, $xml_event:expr, $tag:expr, $xmlns_map:expr) => {{
     if let Some((e, empty_tag)) = $xml_event {
       (e, empty_tag)
     } else {
@@ -155,15 +155,15 @@ macro_rules! expect_event_start {
         match $xml_reader.next()? {
           quick_xml::events::Event::Start(b) => break (b, false),
           quick_xml::events::Event::Empty(b) => break (b, true),
-          quick_xml::events::Event::Eof => {
-            return Err(super::super::common::SdkError::UnknownError)
-          }
+          quick_xml::events::Event::Eof => Err(super::super::common::SdkError::CommonError(
+            "Unexpected end of file".into(),
+          ))?,
           _ => continue,
         }
       };
 
-      match e.name().as_ref() {
-        $tag_prefix | $tag => (),
+      match e.local_name().as_ref() {
+        $tag => (),
         _ => {
           Err(super::super::common::SdkError::MismatchError {
             expected: String::from_utf8_lossy($tag).to_string(),
@@ -171,6 +171,8 @@ macro_rules! expect_event_start {
           })?;
         }
       }
+
+      super::super::common::update_namespace_map($xml_reader, &e, &mut $xmlns_map)?;
 
       (e, empty_tag)
     }
@@ -188,7 +190,7 @@ where
     match reader.next()? {
       quick_xml::events::Event::Start(_) => level += 1,
       quick_xml::events::Event::End(_) => level -= 1,
-      quick_xml::events::Event::Eof => Err(SdkError::UnknownError)?,
+      quick_xml::events::Event::Eof => Err(SdkError::CommonError("Unexpected end of file".into()))?,
       _ => {}
     }
   }
@@ -215,7 +217,55 @@ where
         }
       }
       quick_xml::events::Event::End(e) if e.name() == start.name() => return Ok(text),
-      _ => Err(SdkError::UnknownError)?,
+      quick_xml::events::Event::Eof => Err(SdkError::CommonError("Unexpected end of file".into()))?,
+      event => Err(SdkError::CommonError(format!(
+        "Unexpected event: {event:?}"
+      )))?,
     }
+  }
+}
+
+pub(crate) fn update_namespace_map<'a, R>(
+  xml_reader: &R,
+  e: &quick_xml::events::BytesStart<'a>,
+  xmlns_map: &mut HashMap<String, String>,
+) -> Result<(), SdkError>
+where
+  R: XmlReader<'a>,
+{
+  for attr in e.attributes().with_checks(false) {
+    let attr = attr?;
+    if let Some(namespace) = attr.key.as_namespace_binding() {
+      let value = attr
+        .decode_and_unescape_value(xml_reader.decoder())?
+        .to_string();
+      let key = match namespace {
+        PrefixDeclaration::Named(prefix) => String::from_utf8_lossy(prefix),
+        PrefixDeclaration::Default => "".into(),
+      };
+      xmlns_map.insert(key.to_string(), value);
+    }
+  }
+  Ok(())
+}
+
+pub(crate) fn get_element_namespace<'a, 'b>(
+  e: &quick_xml::events::BytesStart<'a>,
+  xmlns_map: &'b HashMap<String, String>,
+) -> Result<&'b str, SdkError> {
+  let prefix = e
+    .name()
+    .prefix()
+    .map(|prefix| String::from_utf8_lossy(prefix.as_ref()).to_string());
+
+  if let Some(ns) = prefix {
+    Ok(
+      xmlns_map
+        .get(&ns)
+        .ok_or(SdkError::CommonError("Unknown prefix: {ns}".into()))?
+        .as_str(),
+    )
+  } else {
+    Ok(xmlns_map.get("").map(|ns| ns.as_str()).unwrap_or(""))
   }
 }

--- a/crates/ooxmlsdk-build/src/includes/common/alternate_content.rs
+++ b/crates/ooxmlsdk-build/src/includes/common/alternate_content.rs
@@ -1,4 +1,4 @@
-use super::{defs, SdkError, XmlReader};
+use super::{defs, get_element_namespace, update_namespace_map, SdkError, XmlReader};
 
 #[derive(Default)]
 pub struct AlternateContentStack {
@@ -13,17 +13,22 @@ impl AlternateContentStack {
     &mut self,
     e: quick_xml::events::BytesStart<'a>,
     xml_reader: &mut R,
+    xmlns_map: &mut std::collections::HashMap<String, String>,
   ) -> Result<Option<quick_xml::events::BytesStart<'a>>, SdkError>
   where
     R: XmlReader<'a>,
   {
-    match e.local_name().as_ref() {
-      b"AlternateContent" => {
+    update_namespace_map(xml_reader, &e, xmlns_map)?;
+    match (
+      e.local_name().as_ref(),
+      get_element_namespace(&e, xmlns_map)?,
+    ) {
+      (b"AlternateContent", "http://schemas.openxmlformats.org/markup-compatibility/2006") => {
         self.stack.push(false);
         Ok(None)
       }
-      b"Choice" => {
-        let mut skip = *self.stack.last().ok_or(SdkError::UnknownError)?;
+      (b"Choice", "http://schemas.openxmlformats.org/markup-compatibility/2006") => {
+        let mut skip = *wrap_error(self.stack.last())?;
         // If we are not skipping choices, see if we should skip this choice
         if !skip {
           for attr in e.attributes().with_checks(false) {
@@ -41,8 +46,8 @@ impl AlternateContentStack {
         }
         Ok(None)
       }
-      b"Fallback" => {
-        let skip = *self.stack.last().ok_or(SdkError::UnknownError)?;
+      (b"Fallback", "http://schemas.openxmlformats.org/markup-compatibility/2006") => {
+        let skip = *wrap_error(self.stack.last())?;
         if skip {
           super::skip_element(xml_reader)?;
         }
@@ -56,15 +61,21 @@ impl AlternateContentStack {
   pub fn on_end<'a>(&mut self, e: quick_xml::events::BytesEnd<'a>) -> Result<(), SdkError> {
     match e.local_name().as_ref() {
       b"AlternateContent" => {
-        self.stack.pop().ok_or(SdkError::UnknownError)?;
+        wrap_error(self.stack.pop())?;
       }
       // We'll only hit this if we don't skip the choice, so we want to skip all choices after this
       b"Choice" | b"Fallback" => {
-        let last = self.stack.last_mut().ok_or(SdkError::UnknownError)?;
+        let last = wrap_error(self.stack.last_mut())?;
         *last = true;
       }
       _ => (),
     }
     Ok(())
   }
+}
+
+fn wrap_error<T>(opt: Option<T>) -> Result<T, SdkError> {
+  opt.ok_or(SdkError::CommonError(
+    "Error parsing AlternateContent".into(),
+  ))
 }

--- a/crates/ooxmlsdk-build/src/includes/packages/opc_content_types.rs
+++ b/crates/ooxmlsdk-build/src/includes/packages/opc_content_types.rs
@@ -20,7 +20,7 @@ impl std::str::FromStr for Types {
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     let mut xml_reader = super::super::common::from_str_inner(s)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
   }
 }
 
@@ -30,18 +30,18 @@ impl Types {
   ) -> Result<Self, super::super::common::SdkError> {
     let mut xml_reader = super::super::common::from_reader_inner(reader)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
   }
 
   pub(crate) fn deserialize_inner<'de, R: super::super::common::XmlReader<'de>>(
     xml_reader: &mut R,
     xml_event: Option<(quick_xml::events::BytesStart<'de>, bool)>,
+    mut xmlns_map: std::collections::HashMap<String, String>,
   ) -> Result<Self, super::super::common::SdkError> {
     let (e, empty_tag) =
-      super::super::common::expect_event_start!(xml_reader, xml_event, b"w:Types", b"Types");
+      super::super::common::expect_event_start!(xml_reader, xml_event, b"Types", xmlns_map);
 
     let mut xmlns = None;
-    let mut xmlns_map = std::collections::HashMap::<String, String>::new();
     let mut mc_ignorable = None;
 
     let mut children = vec![];
@@ -64,16 +64,7 @@ impl Types {
               .into_owned(),
           );
         }
-        key => {
-          if key.starts_with(b"xmlns:") {
-            xmlns_map.insert(
-              String::from_utf8_lossy(&key[6..]).to_string(),
-              attr
-                .decode_and_unescape_value(xml_reader.decoder())?
-                .into_owned(),
-            );
-          }
-        }
+        _ => (),
       }
     }
 
@@ -84,32 +75,37 @@ impl Types {
 
         match xml_reader.next()? {
           quick_xml::events::Event::Start(e) => {
+            super::super::common::update_namespace_map(xml_reader, &e, &mut xmlns_map)?;
             e_opt = Some(e);
           }
           quick_xml::events::Event::Empty(e) => {
             e_empty = true;
             e_opt = Some(e);
           }
-          quick_xml::events::Event::End(e) => match e.name().as_ref() {
-            b"w:Types" | b"Types" => {
+          quick_xml::events::Event::End(e) => {
+            if e.local_name().as_ref() == b"Types" {
               break;
             }
-            _ => (),
-          },
-          quick_xml::events::Event::Eof => Err(super::super::common::SdkError::UnknownError)?,
+          }
+          quick_xml::events::Event::Eof => Err(super::super::common::SdkError::CommonError(
+            "Unexpected end of file".into(),
+          ))?,
           _ => (),
         }
 
         if let Some(e) = e_opt {
-          match e.name().as_ref() {
-            b"w:Default" | b"Default" => {
+          match (
+            e.local_name().as_ref(),
+            super::super::common::get_element_namespace(&e, &xmlns_map)?,
+          ) {
+            (b"Default", "http://schemas.openxmlformats.org/package/2006/content-types") => {
               children.push(TypesChildChoice::Default(std::boxed::Box::new(
-                Default::deserialize_inner(xml_reader, Some((e, e_empty)))?,
+                Default::deserialize_inner(xml_reader, Some((e, e_empty)), xmlns_map.clone())?,
               )));
             }
-            b"w:Override" | b"Override" => {
+            (b"Override", "http://schemas.openxmlformats.org/package/2006/content-types") => {
               children.push(TypesChildChoice::Override(std::boxed::Box::new(
-                Override::deserialize_inner(xml_reader, Some((e, e_empty)))?,
+                Override::deserialize_inner(xml_reader, Some((e, e_empty)), xmlns_map.clone())?,
               )));
             }
             _ => Err(super::super::common::SdkError::CommonError(
@@ -216,7 +212,7 @@ impl std::str::FromStr for Default {
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     let mut xml_reader = super::super::common::from_str_inner(s)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
   }
 }
 
@@ -226,15 +222,16 @@ impl Default {
   ) -> Result<Self, super::super::common::SdkError> {
     let mut xml_reader = super::super::common::from_reader_inner(reader)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
   }
 
   pub fn deserialize_inner<'de, R: super::super::common::XmlReader<'de>>(
     xml_reader: &mut R,
     xml_event: Option<(quick_xml::events::BytesStart<'de>, bool)>,
+    mut xmlns_map: std::collections::HashMap<String, String>,
   ) -> Result<Self, super::super::common::SdkError> {
     let (e, _) =
-      super::super::common::expect_event_start!(xml_reader, xml_event, b"w:Default", b"Default");
+      super::super::common::expect_event_start!(xml_reader, xml_event, b"Default", xmlns_map);
 
     let mut extension = None;
     let mut content_type = None;
@@ -326,7 +323,7 @@ impl std::str::FromStr for Override {
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     let mut xml_reader = super::super::common::from_str_inner(s)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
   }
 }
 
@@ -336,15 +333,16 @@ impl Override {
   ) -> Result<Self, super::super::common::SdkError> {
     let mut xml_reader = super::super::common::from_reader_inner(reader)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, std::default::Default::default())
   }
 
   pub(crate) fn deserialize_inner<'de, R: super::super::common::XmlReader<'de>>(
     xml_reader: &mut R,
     xml_event: Option<(quick_xml::events::BytesStart<'de>, bool)>,
+    mut xmlns_map: std::collections::HashMap<String, String>,
   ) -> Result<Self, super::super::common::SdkError> {
     let (e, _) =
-      super::super::common::expect_event_start!(xml_reader, xml_event, b"w:Override", b"Override");
+      super::super::common::expect_event_start!(xml_reader, xml_event, b"Override", xmlns_map);
 
     let mut content_type = None;
     let mut part_name = None;

--- a/crates/ooxmlsdk-build/src/includes/packages/opc_core_properties.rs
+++ b/crates/ooxmlsdk-build/src/includes/packages/opc_core_properties.rs
@@ -26,7 +26,7 @@ impl std::str::FromStr for CoreProperties {
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     let mut xml_reader = super::super::common::from_str_inner(s)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, Default::default())
   }
 }
 
@@ -36,23 +36,22 @@ impl CoreProperties {
   ) -> Result<Self, super::super::common::SdkError> {
     let mut xml_reader = super::super::common::from_reader_inner(reader)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, Default::default())
   }
 
   pub fn deserialize_inner<'de, R: super::super::common::XmlReader<'de>>(
     xml_reader: &mut R,
     xml_event: Option<(quick_xml::events::BytesStart<'de>, bool)>,
+    mut xmlns_map: std::collections::HashMap<String, String>,
   ) -> Result<Self, super::super::common::SdkError> {
     let (e, empty_tag) = super::super::common::expect_event_start!(
       xml_reader,
       xml_event,
-      b"cp:coreProperties",
-      b"coreProperties"
+      b"coreProperties",
+      xmlns_map
     );
 
     let mut xmlns = None;
-
-    let mut xmlns_map = std::collections::HashMap::<String, String>::new();
 
     let mut mc_ignorable = None;
 
@@ -103,16 +102,7 @@ impl CoreProperties {
               .to_string(),
           );
         }
-        key => {
-          if key.starts_with(b"xmlns:") {
-            xmlns_map.insert(
-              String::from_utf8_lossy(&key[6..]).to_string(),
-              attr
-                .decode_and_unescape_value(xml_reader.decoder())?
-                .to_string(),
-            );
-          }
-        }
+        _ => (),
       }
     }
 
@@ -121,34 +111,42 @@ impl CoreProperties {
         match xml_reader.next()? {
           quick_xml::events::Event::Start(e) => {
             let element_text = super::super::common::read_element_text(xml_reader, &e)?;
-            match e.name().as_ref() {
-              b"cp:category" => category = element_text,
-              b"cp:contentStatus" => content_status = element_text,
-              b"dcterms:created" => created = element_text,
-              b"dc:creator" => creator = element_text,
-              b"dc:description" => description = element_text,
-              b"dc:identifier" => identifier = element_text,
-              b"cp:keywords" => keywords = element_text,
-              b"dc:language" => language = element_text,
-              b"cp:lastModifiedBy" => last_modified_by = element_text,
-              b"cp:lastPrinted" => last_printed = element_text,
-              b"dcterms:modified" => modified = element_text,
-              b"cp:revision" => revision = element_text,
-              b"dc:subject" => subject = element_text,
-              b"dc:title" => title = element_text,
-              b"cp:version" => version = element_text,
+            const CP: &str =
+              "http://schemas.openxmlformats.org/package/2006/metadata/core-properties";
+            const DCTERMS: &str = "http://purl.org/dc/terms/";
+            const DC: &str = "http://purl.org/dc/elements/1.1/";
+            match (
+              e.local_name().as_ref(),
+              super::super::common::get_element_namespace(&e, &xmlns_map)?,
+            ) {
+              (b"category", CP) => category = element_text,
+              (b"contentStatus", CP) => content_status = element_text,
+              (b"created", DCTERMS) => created = element_text,
+              (b"creator", DC) => creator = element_text,
+              (b"description", DC) => description = element_text,
+              (b"identifier", DC) => identifier = element_text,
+              (b"keywords", CP) => keywords = element_text,
+              (b"language", DC) => language = element_text,
+              (b"lastModifiedBy", CP) => last_modified_by = element_text,
+              (b"lastPrinted", CP) => last_printed = element_text,
+              (b"modified", DCTERMS) => modified = element_text,
+              (b"revision", CP) => revision = element_text,
+              (b"subject", DC) => subject = element_text,
+              (b"title", DC) => title = element_text,
+              (b"version", CP) => version = element_text,
               _ => Err(super::super::common::SdkError::CommonError(
                 "coreProperties".to_string(),
               ))?,
             }
           }
-          quick_xml::events::Event::End(e) => match e.name().as_ref() {
-            b"cp:coreProperties" | b"coreProperties" => {
+          quick_xml::events::Event::End(e) => {
+            if e.local_name().as_ref() == b"coreProperties" {
               break;
             }
-            _ => (),
-          },
-          quick_xml::events::Event::Eof => Err(super::super::common::SdkError::UnknownError)?,
+          }
+          quick_xml::events::Event::Eof => Err(super::super::common::SdkError::CommonError(
+            "Unexpected end of file".into(),
+          ))?,
           _ => (),
         }
       }

--- a/crates/ooxmlsdk-build/src/includes/packages/opc_relationships.rs
+++ b/crates/ooxmlsdk-build/src/includes/packages/opc_relationships.rs
@@ -12,7 +12,7 @@ impl std::str::FromStr for Relationships {
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     let mut xml_reader = super::super::common::from_str_inner(s)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, Default::default())
   }
 }
 
@@ -22,23 +22,18 @@ impl Relationships {
   ) -> Result<Self, super::super::common::SdkError> {
     let mut xml_reader = super::super::common::from_reader_inner(reader)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, Default::default())
   }
 
   pub fn deserialize_inner<'de, R: super::super::common::XmlReader<'de>>(
     xml_reader: &mut R,
     xml_event: Option<(quick_xml::events::BytesStart<'de>, bool)>,
+    mut xmlns_map: std::collections::HashMap<String, String>,
   ) -> Result<Self, super::super::common::SdkError> {
-    let (e, empty_tag) = super::super::common::expect_event_start!(
-      xml_reader,
-      xml_event,
-      b"w:Relationships",
-      b"Relationships"
-    );
+    let (e, empty_tag) =
+      super::super::common::expect_event_start!(xml_reader, xml_event, b"Relationships", xmlns_map);
 
     let mut xmlns = None;
-
-    let mut xmlns_map = std::collections::HashMap::<String, String>::new();
 
     let mut mc_ignorable = None;
 
@@ -61,16 +56,7 @@ impl Relationships {
               .to_string(),
           );
         }
-        key => {
-          if key.starts_with(b"xmlns:") {
-            xmlns_map.insert(
-              String::from_utf8_lossy(&key[6..]).to_string(),
-              attr
-                .decode_and_unescape_value(xml_reader.decoder())?
-                .to_string(),
-            );
-          }
-        }
+        _ => (),
       }
     }
 
@@ -87,27 +73,33 @@ impl Relationships {
             e_empty = true;
             e_opt = Some(e);
           }
-          quick_xml::events::Event::End(e) => match e.name().as_ref() {
-            b"w:Relationships" | b"Relationships" => {
+          quick_xml::events::Event::End(e) => {
+            if e.local_name().as_ref() == b"Relationships" {
               break;
             }
-            _ => (),
-          },
-          quick_xml::events::Event::Eof => Err(super::super::common::SdkError::UnknownError)?,
+          }
+          quick_xml::events::Event::Eof => Err(super::super::common::SdkError::CommonError(
+            "Unexpected end of file".into(),
+          ))?,
           _ => (),
         }
 
         if let Some(e) = e_opt {
-          match e.name().as_ref() {
-            b"w:Relationship" | b"Relationship" => {
+          super::super::common::update_namespace_map(xml_reader, &e, &mut xmlns_map)?;
+          match (
+            e.local_name().as_ref(),
+            super::super::common::get_element_namespace(&e, &xmlns_map)?,
+          ) {
+            (b"Relationship", "http://schemas.openxmlformats.org/package/2006/relationships") => {
               relationship.push(Relationship::deserialize_inner(
                 xml_reader,
                 Some((e, e_empty)),
+                xmlns_map.clone(),
               )?);
             }
 
             _ => Err(super::super::common::SdkError::CommonError(
-              "Types".to_string(),
+              "Relationship".to_string(),
             ))?,
           }
         }
@@ -203,7 +195,7 @@ impl Relationship {
   pub fn from_str(s: &str) -> Result<Self, super::super::common::SdkError> {
     let mut xml_reader = super::super::common::from_str_inner(s)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, Default::default())
   }
 
   pub fn from_reader<R: std::io::BufRead>(
@@ -211,19 +203,16 @@ impl Relationship {
   ) -> Result<Self, super::super::common::SdkError> {
     let mut xml_reader = super::super::common::from_reader_inner(reader)?;
 
-    Self::deserialize_inner(&mut xml_reader, None)
+    Self::deserialize_inner(&mut xml_reader, None, Default::default())
   }
 
   pub fn deserialize_inner<'de, R: super::super::common::XmlReader<'de>>(
     xml_reader: &mut R,
     xml_event: Option<(quick_xml::events::BytesStart<'de>, bool)>,
+    mut xmlns_map: std::collections::HashMap<String, String>,
   ) -> Result<Self, super::super::common::SdkError> {
-    let (e, _) = super::super::common::expect_event_start!(
-      xml_reader,
-      xml_event,
-      b"w:Relationship",
-      b"Relationship"
-    );
+    let (e, _) =
+      super::super::common::expect_event_start!(xml_reader, xml_event, b"Relationship", xmlns_map);
 
     let mut target_mode = None;
 


### PR DESCRIPTION
This removes the expectation of hardcoded element namespace prefixes. Instead, it compares the prefix with the prefixes supplied via the `xmlns:...` attributes and checks that the namespace URI is as expected.

This meant changing the API of the generated  `deserialize_inner` methods to include `xmlns_map`, which maps from discovered prefixes to URIs. `update_namespace_map` and `get_element_namespace` have been added to update the map with `xmlns` attributes from the current element, and resolve the namespace URI for the currently element. The namespace URI resolution looks for the element's prefix in the `xmlns_map` and returns the URI. If the element doesn't have a prefix, it looks in the map for the empty prefix (`""`) and returns an empty string if it's not in the map.

A prefix on an element which doesn't appear in `xmlns_map` is a hard error.