### PR TITLE
Support absolute ZIP file references

### DIFF
--- a/crates/ooxmlsdk-build/src/generator/open_xml_part.rs
+++ b/crates/ooxmlsdk-build/src/generator/open_xml_part.rs
@@ -395,7 +395,7 @@ pub fn gen_open_xml_parts(part: &OpenXmlPart, gen_context: &GenContext) -> Token
             let target_path = match relationship.target_mode.as_ref() {
               Some(crate::schemas::opc_relationships::TargetMode::External) => relationship.target.clone(),
               _ => crate::common::resolve_zip_file_path(
-                  &format!("{}{}", child_parent_path, relationship.target),
+                  &crate::common::combine_paths(&child_parent_path, &relationship.target)
               ),
             };
 
@@ -427,7 +427,7 @@ pub fn gen_open_xml_parts(part: &OpenXmlPart, gen_context: &GenContext) -> Token
             let target_path = match relationship.target_mode.as_ref() {
               Some(crate::schemas::opc_relationships::TargetMode::External) => relationship.target.clone(),
               _ => crate::common::resolve_zip_file_path(
-                  &format!("{}{}", child_parent_path, relationship.target),
+                  &crate::common::combine_paths(&child_parent_path, &relationship.target)
               ),
             };
 

--- a/crates/ooxmlsdk-build/src/includes/common.rs
+++ b/crates/ooxmlsdk-build/src/includes/common.rs
@@ -119,6 +119,14 @@ pub fn resolve_zip_file_path(path: &str) -> String {
   stack.join("/")
 }
 
+pub fn combine_paths(parent_path: &str, child_path: &str) -> String {
+  if child_path.starts_with("/") {
+    child_path.to_string()
+  } else {
+    format!("{}{}", parent_path, child_path)
+  }
+}
+
 #[inline]
 pub(crate) fn from_reader_inner<R: BufRead>(reader: R) -> Result<IoReader<R>, SdkError> {
   let mut xml_reader = quick_xml::Reader::from_reader(reader);


### PR DESCRIPTION
The `target` in a relationship can be an absolute path. This was previously not supported, and would lead to paths like `ppt/ppt/...` if the relationship target was formatted like `/ppt/...`